### PR TITLE
Fix Swagger UI update workflow and add automated API version links

### DIFF
--- a/.github/workflows/update-api-versions.yml
+++ b/.github/workflows/update-api-versions.yml
@@ -1,0 +1,120 @@
+name: Update API Versions in README
+
+on:
+  schedule:
+    - cron: "0 2 * * *"
+  workflow_dispatch:
+
+jobs:
+  update-versions:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Update API version links in README
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python3 - << 'PYEOF'
+          import subprocess, json, re, sys
+
+          BASE_RAW = "https://raw.githubusercontent.com/cloud-barista"
+          BASE_UI  = "https://cloud-barista.github.io/api/?url="
+
+          PROJECTS = [
+            {"id": "cb-spider",       "repo": "cb-spider",       "branch": "master", "docs": [
+              {"label": None, "path": "api/swagger.yaml"},
+            ]},
+            {"id": "cb-tumblebug",    "repo": "cb-tumblebug",    "branch": "main",   "docs": [
+              {"label": None, "path": "src/interface/rest/docs/swagger.yaml"},
+            ]},
+            {"id": "cm-honeybee",     "repo": "cm-honeybee",     "branch": "main",   "docs": [
+              {"label": "Agent",  "path": "agent/pkg/api/rest/docs/swagger.yaml"},
+              {"label": "Server", "path": "server/pkg/api/rest/docs/swagger.yaml"},
+            ]},
+            {"id": "cm-beetle",       "repo": "cm-beetle",       "branch": "main",   "docs": [
+              {"label": None, "path": "api/swagger.yaml"},
+            ]},
+            {"id": "cm-grasshopper",  "repo": "cm-grasshopper",  "branch": "main",   "docs": [
+              {"label": None, "path": "pkg/api/rest/docs/swagger.yaml"},
+            ]},
+            {"id": "cm-damselfly",    "repo": "cm-damselfly",    "branch": "main",   "docs": [
+              {"label": None, "path": "api/swagger.yaml"},
+            ]},
+            {"id": "cm-cicada",       "repo": "cm-cicada",       "branch": "main",   "docs": [
+              {"label": None, "path": "pkg/api/rest/docs/swagger.yaml"},
+            ]},
+            {"id": "cm-ant",          "repo": "cm-ant",          "branch": "main",   "docs": [
+              {"label": None, "path": "api/swagger.yaml"},
+            ]},
+            {"id": "mc-data-manager", "repo": "mc-data-manager", "branch": "main",   "docs": [
+              {"label": None, "path": "websrc/docs/swagger.yaml"},
+            ]},
+            {"id": "mc-terrarium",    "repo": "mc-terrarium",    "branch": "main",   "docs": [
+              {"label": None, "path": "api/swagger.yaml"},
+            ]},
+          ]
+
+          def swagger_url(repo, ref, path):
+            return f"{BASE_UI}{BASE_RAW}/{repo}/{ref}/{path}"
+
+          def get_releases(repo, count=2):
+            result = subprocess.run(
+              ["gh", "api", f"repos/cloud-barista/{repo}/releases?per_page={count}"],
+              capture_output=True, text=True
+            )
+            if result.returncode != 0:
+              print(f"Warning: failed to get releases for {repo}", file=sys.stderr)
+              return []
+            try:
+              return [r["tag_name"] for r in json.loads(result.stdout)[:count]]
+            except Exception as e:
+              print(f"Warning: could not parse releases for {repo}: {e}", file=sys.stderr)
+              return []
+
+          def build_block(project, releases):
+            repo, branch, docs = project["repo"], project["branch"], project["docs"]
+            lines = ["- **API Documentation**:"]
+            if len(docs) == 1 and docs[0]["label"] is None:
+              path = docs[0]["path"]
+              lines.append(f"  - [latest dev ({branch})]({swagger_url(repo, branch, path)})")
+              for tag in releases:
+                lines.append(f"  - [{tag}]({swagger_url(repo, tag, path)})")
+            else:
+              for doc in docs:
+                lines.append(f"  - **{doc['label']}**:")
+                lines.append(f"    - [latest dev ({branch})]({swagger_url(repo, branch, doc['path'])})")
+                for tag in releases:
+                  lines.append(f"    - [{tag}]({swagger_url(repo, tag, doc['path'])})")
+            return "\n".join(lines)
+
+          with open("README.md", "r") as f:
+            content = f.read()
+
+          for project in PROJECTS:
+            pid      = project["id"]
+            releases = get_releases(project["repo"])
+            block    = build_block(project, releases)
+            start    = f"<!-- VERSIONS:{pid}:START -->"
+            end      = f"<!-- VERSIONS:{pid}:END -->"
+            pattern  = re.compile(r'[ \t]*' + re.escape(start) + r".*?" + r'[ \t]*' + re.escape(end), re.DOTALL)
+            new_content = pattern.sub(f"{start}\n{block}\n{end}", content)
+            if new_content == content:
+              print(f"Warning: markers not found for {pid}", file=sys.stderr)
+            content = new_content
+
+          with open("README.md", "w") as f:
+            f.write(content)
+
+          print("README.md updated successfully")
+          PYEOF
+
+      - name: Commit and push if changed
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git diff --quiet README.md || (
+            git add README.md &&
+            git commit -m "Update API version links in README" &&
+            git push
+          )

--- a/.github/workflows/update-swagger.yml
+++ b/.github/workflows/update-swagger.yml
@@ -16,29 +16,43 @@ jobs:
           echo "release_tag=$release_tag" >> $GITHUB_OUTPUT
           current_tag=$(<swagger-ui.version)
           echo "current_tag=$current_tag" >> $GITHUB_OUTPUT
+          
+          # Extract major.minor versions for comparison
+          current_version=$(echo "$current_tag" | sed 's/^v//' | cut -d. -f1-2)
+          release_version=$(echo "$release_tag" | sed 's/^v//' | cut -d. -f1-2)
+          
+          echo "current_version=$current_version" >> $GITHUB_OUTPUT
+          echo "release_version=$release_version" >> $GITHUB_OUTPUT
+          
+          # Check if major or minor version changed
+          if [ "$current_version" != "$release_version" ]; then
+            echo "should_update=true" >> $GITHUB_OUTPUT
+            echo "Major or minor version changed: $current_version -> $release_version"
+          else
+            echo "should_update=false" >> $GITHUB_OUTPUT
+            echo "Only patch version changed, skipping update"
+          fi
       - name: Update Swagger UI
-        if: steps.swagger-ui.outputs.current_tag != steps.swagger-ui.outputs.release_tag
+        if: steps.swagger-ui.outputs.should_update == 'true'
         env:
           RELEASE_TAG: ${{ steps.swagger-ui.outputs.release_tag }}
           SWAGGER_YAML: "swagger.yaml"
         run: |
-          # Delete the dist directory and index.html
-          rm -fr dist index.html
+          # Delete the dist directory only (index.html is customized and must not be overwritten)
+          rm -fr dist
           # Download the release
           curl -sL -o $RELEASE_TAG https://api.github.com/repos/swagger-api/swagger-ui/tarball/$RELEASE_TAG
           # Extract the dist directory
           tar -xzf $RELEASE_TAG --strip-components=1 $(tar -tzf $RELEASE_TAG | head -1 | cut -f1 -d"/")/dist
           rm $RELEASE_TAG
-          # Move index.html to the root
-          mv dist/index.html .
-          # Fix references in dist/swagger-initializer and index.html
+          # Remove index.html extracted into dist (the root index.html is customized)
+          rm -f dist/index.html
+          # Fix references in dist/swagger-initializer.js
           sed -i "s|https://petstore.swagger.io/v2/swagger.json|$SWAGGER_YAML|g" dist/swagger-initializer.js
-          sed -i "s|href=\"./|href=\"dist/|g" index.html
-          sed -i "s|src=\"./|src=\"dist/|g" index.html
-          sed -i "s|href=\"index|href=\"dist/index|g" index.html
           # Update current release
           echo ${{ steps.swagger-ui.outputs.release_tag }} > swagger-ui.version
       - name: Create Pull Request
+        if: steps.swagger-ui.outputs.should_update == 'true'
         uses: peter-evans/create-pull-request@v8
         with:
           commit-message: Update swagger-ui to ${{ steps.swagger-ui.outputs.release_tag }}

--- a/README.md
+++ b/README.md
@@ -13,9 +13,7 @@ Welcome to the centralized API documentation portal for the Cloud-Barista ecosys
 
 ⚠️ **Note**: Cloud-Barista is under active development (pre-v1.0) and is not yet stable or secure for production use.
 
-**Latest Documentation (Development Branch)**: The API documentation shown here reflects the latest development versions and may include unreleased features.
-
-**Stable Versions**: Please use the documentation corresponding to a specific stable release tag.
+Each project lists API documentation for the **latest development branch** as well as the **two most recent stable releases**, updated automatically every day.
 
 **Get Involved**: Found an issue or have an idea? Please open an issue or connect with us on Slack. We welcome your feedback!
 
@@ -23,17 +21,15 @@ Welcome to the centralized API documentation portal for the Cloud-Barista ecosys
 
 ### Method 1: Direct Access
 
-Click on any "API documentation" link below to view the Swagger UI directly.
+Click on any API documentation link below to view the Swagger UI directly.
 
 ### Method 2: Custom URL
 
-Use the URL format: `https://cloud-barista.github.io/api/?url=YOUR_SWAGGER_YAML_URL` to view any Swagger specification.
+Use the URL format below to view any Swagger specification hosted on GitHub:
 
-### Method 3: Version Selection
-
-- Each project link shows the latest development version
-- For stable versions, visit the "Releases" link of each repository
-- Use format: `https://cloud-barista.github.io/api/?url=https://raw.githubusercontent.com/{org}/{repo}/{tag}/path/to/swagger.yaml`
+```
+https://cloud-barista.github.io/api/?url=https://raw.githubusercontent.com/{org}/{repo}/{ref}/path/to/swagger.yaml
+```
 
 ---
 
@@ -42,73 +38,105 @@ Use the URL format: `https://cloud-barista.github.io/api/?url=YOUR_SWAGGER_YAML_
 ### CB-Spider
 
 - **Repository**: https://github.com/cloud-barista/cb-spider
-- **API Documentation**: https://cloud-barista.github.io/api/?url=https://raw.githubusercontent.com/cloud-barista/cb-spider/master/api/swagger.yaml
+<!-- VERSIONS:cb-spider:START -->
+- **API Documentation**:
+  - [latest dev (master)](https://cloud-barista.github.io/api/?url=https://raw.githubusercontent.com/cloud-barista/cb-spider/master/api/swagger.yaml)
+  <!-- VERSIONS:cb-spider:END -->
 - **Releases**: https://github.com/cloud-barista/cb-spider/releases
 
 ### CB-Tumblebug
 
 - **Repository**: https://github.com/cloud-barista/cb-tumblebug
-- **API Documentation**: https://cloud-barista.github.io/api/?url=https://raw.githubusercontent.com/cloud-barista/cb-tumblebug/main/src/interface/rest/docs/swagger.yaml
+<!-- VERSIONS:cb-tumblebug:START -->
+- **API Documentation**:
+  - [latest dev (main)](https://cloud-barista.github.io/api/?url=https://raw.githubusercontent.com/cloud-barista/cb-tumblebug/main/src/interface/rest/docs/swagger.yaml)
+  <!-- VERSIONS:cb-tumblebug:END -->
 - **Releases**: https://github.com/cloud-barista/cb-tumblebug/releases
 
 ### CM-Honeybee
 
 - **Repository**: https://github.com/cloud-barista/cm-honeybee
+<!-- VERSIONS:cm-honeybee:START -->
 - **API Documentation**:
-  - **Agent**: https://cloud-barista.github.io/api/?url=https://raw.githubusercontent.com/cloud-barista/cm-honeybee/main/agent/pkg/api/rest/docs/swagger.yaml
-  - **Server**: https://cloud-barista.github.io/api/?url=https://raw.githubusercontent.com/cloud-barista/cm-honeybee/main/server/pkg/api/rest/docs/swagger.yaml
+  - **Agent**:
+    - [latest dev (main)](https://cloud-barista.github.io/api/?url=https://raw.githubusercontent.com/cloud-barista/cm-honeybee/main/agent/pkg/api/rest/docs/swagger.yaml)
+  - **Server**: - [latest dev (main)](https://cloud-barista.github.io/api/?url=https://raw.githubusercontent.com/cloud-barista/cm-honeybee/main/server/pkg/api/rest/docs/swagger.yaml)
+  <!-- VERSIONS:cm-honeybee:END -->
 - **Releases**: https://github.com/cloud-barista/cm-honeybee/releases
 
 ### CM-Beetle
 
 - **Repository**: https://github.com/cloud-barista/cm-beetle
-- **API Documentation**: https://cloud-barista.github.io/api/?url=https://raw.githubusercontent.com/cloud-barista/cm-beetle/main/api/swagger.yaml
+<!-- VERSIONS:cm-beetle:START -->
+- **API Documentation**:
+  - [latest dev (main)](https://cloud-barista.github.io/api/?url=https://raw.githubusercontent.com/cloud-barista/cm-beetle/main/api/swagger.yaml)
+  <!-- VERSIONS:cm-beetle:END -->
 - **Releases**: https://github.com/cloud-barista/cm-beetle/releases
 
 ### CM-Grasshopper
 
 - **Repository**: https://github.com/cloud-barista/cm-grasshopper
-- **API Documentation**: https://cloud-barista.github.io/api/?url=https://raw.githubusercontent.com/cloud-barista/cm-grasshopper/main/pkg/api/rest/docs/swagger.yaml
+<!-- VERSIONS:cm-grasshopper:START -->
+- **API Documentation**:
+  - [latest dev (main)](https://cloud-barista.github.io/api/?url=https://raw.githubusercontent.com/cloud-barista/cm-grasshopper/main/pkg/api/rest/docs/swagger.yaml)
+  <!-- VERSIONS:cm-grasshopper:END -->
 - **Releases**: https://github.com/cloud-barista/cm-grasshopper/releases
 
 ### CM-Damselfly
 
 - **Repository**: https://github.com/cloud-barista/cm-damselfly
-- **API Documentation**: https://cloud-barista.github.io/api/?url=https://raw.githubusercontent.com/cloud-barista/cm-damselfly/main/api/swagger.yaml
+<!-- VERSIONS:cm-damselfly:START -->
+- **API Documentation**:
+  - [latest dev (main)](https://cloud-barista.github.io/api/?url=https://raw.githubusercontent.com/cloud-barista/cm-damselfly/main/api/swagger.yaml)
+  <!-- VERSIONS:cm-damselfly:END -->
 - **Releases**: https://github.com/cloud-barista/cm-damselfly/releases
 
 ### CM-Cicada
 
 - **Repository**: https://github.com/cloud-barista/cm-cicada
-- **API Documentation**: https://cloud-barista.github.io/api/?url=https://raw.githubusercontent.com/cloud-barista/cm-cicada/main/pkg/api/rest/docs/swagger.yaml
+<!-- VERSIONS:cm-cicada:START -->
+- **API Documentation**:
+  - [latest dev (main)](https://cloud-barista.github.io/api/?url=https://raw.githubusercontent.com/cloud-barista/cm-cicada/main/pkg/api/rest/docs/swagger.yaml)
+  <!-- VERSIONS:cm-cicada:END -->
 - **Releases**: https://github.com/cloud-barista/cm-cicada/releases
 
 ### CM-Ant
 
 - **Repository**: https://github.com/cloud-barista/cm-ant
-- **API Documentation**: https://cloud-barista.github.io/api/?url=https://raw.githubusercontent.com/cloud-barista/cm-ant/main/api/swagger.yaml
+<!-- VERSIONS:cm-ant:START -->
+- **API Documentation**:
+  - [latest dev (main)](https://cloud-barista.github.io/api/?url=https://raw.githubusercontent.com/cloud-barista/cm-ant/main/api/swagger.yaml)
+  <!-- VERSIONS:cm-ant:END -->
 - **Releases**: https://github.com/cloud-barista/cm-ant/releases
 
 ### CM-Butterfly
 
 - **Repository**: https://github.com/cloud-barista/cm-butterfly
+- **API Documentation**: Not available (no REST API specification)
 - **Releases**: https://github.com/cloud-barista/cm-butterfly/releases
 
 ### CM-Mayfly
 
 - **Repository**: https://github.com/cloud-barista/cm-mayfly
+- **API Documentation**: Not available (no REST API specification)
 - **Releases**: https://github.com/cloud-barista/cm-mayfly/releases
 
 ### mc-data-manager
 
 - **Repository**: https://github.com/cloud-barista/mc-data-manager
-- **API Documentation**: https://cloud-barista.github.io/api/?url=https://raw.githubusercontent.com/cloud-barista/mc-data-manager/main/websrc/docs/swagger.yaml
+<!-- VERSIONS:mc-data-manager:START -->
+- **API Documentation**:
+  - [latest dev (main)](https://cloud-barista.github.io/api/?url=https://raw.githubusercontent.com/cloud-barista/mc-data-manager/main/websrc/docs/swagger.yaml)
+  <!-- VERSIONS:mc-data-manager:END -->
 - **Releases**: https://github.com/cloud-barista/mc-data-manager/releases
 
 ### mc-terrarium
 
 - **Repository**: https://github.com/cloud-barista/mc-terrarium
-- **API Documentation**: https://cloud-barista.github.io/api/?url=https://raw.githubusercontent.com/cloud-barista/mc-terrarium/main/api/swagger.yaml
+<!-- VERSIONS:mc-terrarium:START -->
+- **API Documentation**:
+  - [latest dev (main)](https://cloud-barista.github.io/api/?url=https://raw.githubusercontent.com/cloud-barista/mc-terrarium/main/api/swagger.yaml)
+  <!-- VERSIONS:mc-terrarium:END -->
 - **Releases**: https://github.com/cloud-barista/mc-terrarium/releases
 
 ---

--- a/index.html
+++ b/index.html
@@ -3,17 +3,141 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8">
-    <title>Swagger UI</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Cloud-Barista API Documentation Hub</title>
+    <meta name="description" content="Centralized API documentation portal for Cloud-Barista ecosystem projects">
+    <meta name="keywords" content="Cloud-Barista, API, Documentation, Swagger, Multi-cloud">
     <link rel="stylesheet" type="text/css" href="dist/swagger-ui.css" />
     <link rel="stylesheet" type="text/css" href="dist/index.css" />
     <link rel="icon" type="image/png" href="dist/favicon-32x32.png" sizes="32x32" />
     <link rel="icon" type="image/png" href="dist/favicon-16x16.png" sizes="16x16" />
+  
+    <style>
+      #readme-content {
+        margin: 20px auto;
+        max-width: 1200px;
+        padding: 0 20px;
+        display: none;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+        line-height: 1.6;
+      }
+      
+      #readme-content h1 {
+        border-bottom: 2px solid #e1e4e8;
+        padding-bottom: 10px;
+      }
+      
+      #readme-content h2 {
+        border-bottom: 1px solid #e1e4e8;
+        padding-bottom: 8px;
+        margin-top: 32px;
+      }
+      
+      #readme-content h3 {
+        margin-top: 24px;
+        margin-bottom: 16px;
+      }
+      
+      #readme-content blockquote {
+        border-left: 4px solid #dfe2e5;
+        padding-left: 16px;
+        margin-left: 0;
+        color: #6a737d;
+        font-style: italic;
+      }
+      
+      #readme-content code {
+        background-color: rgba(27,31,35,0.05);
+        border-radius: 3px;
+        font-size: 85%;
+        margin: 0;
+        padding: 0.2em 0.4em;
+      }
+      
+      #readme-content a {
+        color: #0366d6;
+        text-decoration: none;
+      }
+      
+      #readme-content a:hover {
+        text-decoration: underline;
+      }
+      
+      #readme-content ul, #readme-content ol {
+        padding-left: 30px;
+      }
+      
+      #readme-content li {
+        margin-bottom: 4px;
+      }
+    </style>
   </head>
 
   <body>
     <div id="swagger-ui"></div>
+    <div id="readme-content"></div>
+
     <script src="dist/swagger-ui-bundle.js" charset="UTF-8"> </script>
     <script src="dist/swagger-ui-standalone-preset.js" charset="UTF-8"> </script>
-    <script src="dist/swagger-initializer.js" charset="UTF-8"> </script>
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"> </script>
+    <script>
+
+      // Custom renderer to generate GitHub-compatible heading IDs so that
+      // Table of Contents anchor links (e.g. #-introduction) work correctly.
+      marked.use({
+        renderer: {
+          heading({ text, depth }) {
+            const plainText = text.replace(/<[^>]*>/g, '');
+            const id = plainText
+              .toLowerCase()
+              .replace(/[^a-z0-9 -]/g, '')
+              .replace(/ /g, '-');
+            return `<h${depth} id="${id}">${text}</h${depth}>\n`;
+          }
+        }
+      });
+
+      function getUrlParameter(name) {
+        name = name.replace(/[\[]/, '\\[').replace(/[\]]/, '\\]');
+        var regex = new RegExp('[\\?&]' + name + '=([^&#]*)');
+        var results = regex.exec(location.search);
+        return results === null ? '' : decodeURIComponent(results[1].replace(/\+/g, ' '));
+      }
+
+      function fetchReadme(url) {
+        fetch(url)
+          .then(response => response.text())
+          .then(text => {
+            document.getElementById('readme-content').style.display = 'block';
+            document.getElementById('readme-content').innerHTML = marked.parse(text);
+          })
+          .catch(error => console.error('Error fetching README:', error));
+      }
+
+      var swaggerUrl = getUrlParameter('url');
+
+      if (!swaggerUrl) {
+        document.getElementById('readme-content').style.display = 'block';
+        fetchReadme('https://raw.githubusercontent.com/cloud-barista/api/main/README.md');
+      } else {
+        const ui = SwaggerUIBundle({
+          url: swaggerUrl,
+          dom_id: '#swagger-ui',
+          deepLinking: true,
+          tagsSorter: "alpha", 
+          operationsSorter: "alpha",
+          presets: [
+            SwaggerUIBundle.presets.apis,
+            SwaggerUIStandalonePreset
+          ],
+          plugins: [
+            SwaggerUIBundle.plugins.DownloadUrl
+          ],
+          layout: "StandaloneLayout"
+        });
+
+        window.ui = ui;
+      }
+    </script>
   </body>
 </html>


### PR DESCRIPTION
- Fix: prevent update-swagger.yml from overwriting customized index.html
  - Replace only the dist/ directory; preserve the custom root index.html
  - Skip PR creation on patch-only version bumps; only trigger on minor/major changes

- Fix: restore custom index.html lost due to PR #20 merge
  - Cloud-Barista API Documentation Hub title and meta tags
  - Custom JavaScript to fetch and render README.md
  - Add GitHub-compatible heading ID renderer to fix TOC anchor links

- Feat: add workflow to auto-update API version links in README (update-api-versions.yml)
  - Runs daily at 02:00 UTC via cron
  - Fetches latest dev branch + 2 most recent releases per project via GitHub API
  - Updates only the <!-- VERSIONS:{id}:START/END --> marker blocks in README.md

- Chore: wrap each project's API Documentation section in version marker blocks